### PR TITLE
Adding support for expect messages

### DIFF
--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,3 +1,5 @@
+import type { Node } from "ts-morph";
+
 /**
  * Expose information coming from the child nodes
  */
@@ -24,9 +26,11 @@ export interface ChildrenContext {
     useTest?: boolean;
 
     /**
-     * If true, the playwright expect is used in the descendants.
+     * If defined, the playwright expect is used in the descendants.
+     * When defined, messages is an array of messages to attach
+     * to the expect call.
      */
-    useExpect?: boolean;
+    useExpect?: { messages: (string | Node)[] };
 
     /**
      * If true, the Locator type is used in the descendants.

--- a/tests/playwright/src/callExpression.spec.ts
+++ b/tests/playwright/src/callExpression.spec.ts
@@ -40,9 +40,48 @@ test.describe('callExpression conversion', () => {
 		// expect(true).toBeTruthy();
 		expect(true).toBeTruthy();
 
+		// expect(true).toBeTruthy("true should be truthy");
+		expect(true, 'true should be truthy').toBeTruthy();
+
+		// expect(true).withContext("true should be truthy").toBeTruthy();
+		expect(true, 'true should be truthy').toBeTruthy();
+
+		// expect(true).withContext("true should be truthy").toBeTruthy("true should really be truthy");
+		expect(true, 'true should be truthy, true should really be truthy').toBeTruthy();
+
+		// expect(true).withContext("a").withContext("b").toBeTruthy();
+		expect(true, 'a, b').toBeTruthy();
+
+		// expect(true).withContext("a").withContext("b").toBeTruthy("c");
+		expect(true, 'a, b, c').toBeTruthy();
+
+		// expect(true).withContext("a").toBeTruthy("b");
+		expect(true, 'a, b').toBeTruthy();
+
+		// expect(false).not.toBeTruthy();
+		expect(false).not.toBeTruthy();
+
+		// expect(false).not.toBeTruthy("false should not be truthy");
+		expect(false, 'false should not be truthy').not.toBeTruthy();
+
+		// expect(["something"]).toContain("something");
+		expect(["something"]).toContain("something");
+
+		// expect(["something"]).toContain("something", "should contain 'something'");
+		expect(["something"], 'should contain \'something\'').toContain("something");
+
+		// expect(["something"]).not.toContain("wrong");
+		expect(["something"]).not.toContain("wrong");
+
+		// expect(["something"]).not.toContain("wrong", "should not contain 'wrong'");
+		expect(["something"], 'should not contain \'wrong\'').not.toContain("wrong");
+
 		// expect($$('.a').count()).toBe(0);
 		expect(await page.locator('.a').count()).toBe(0);
 
+		const zero = 0;
+		// expect($$('.a').count()).toBe(0, "should have " + zero + " .a element");
+		expect(await page.locator('.a').count(), `should have ${zero} .a element`).toBe(0);
 	});
 
 	test('should add await when required', async ({page}) => {

--- a/tests/protractor/src/callExpression.spec.ts
+++ b/tests/protractor/src/callExpression.spec.ts
@@ -35,9 +35,48 @@ describe('callExpression conversion', () => {
 		// expect(true).toBeTruthy();
 		expect(true).toBeTruthy();
 
+		// expect(true).toBeTruthy("true should be truthy");
+		expect(true).toBeTruthy("true should be truthy");
+
+		// expect(true).withContext("true should be truthy").toBeTruthy();
+		expect(true).withContext("true should be truthy").toBeTruthy();
+
+		// expect(true).withContext("true should be truthy").toBeTruthy("true should really be truthy");
+		expect(true).withContext("true should be truthy").toBeTruthy("true should really be truthy");
+
+		// expect(true).withContext("a").withContext("b").toBeTruthy();
+		expect(true).withContext("a").withContext("b").toBeTruthy();
+
+		// expect(true).withContext("a").withContext("b").toBeTruthy("c");
+		expect(true).withContext("a").withContext("b").toBeTruthy("c");
+
+		// expect(true).withContext("a").toBeTruthy("b");
+		expect(true).withContext("a").toBeTruthy("b");
+
+		// expect(false).not.toBeTruthy();
+		expect(false).not.toBeTruthy();
+
+		// expect(false).not.toBeTruthy("false should not be truthy");
+		expect(false).not.toBeTruthy("false should not be truthy");
+
+		// expect(["something"]).toContain("something");
+		expect(["something"]).toContain("something");
+
+		// expect(["something"]).toContain("something", "should contain 'something'");
+		expect(["something"]).toContain("something", "should contain 'something'");
+
+		// expect(["something"]).not.toContain("wrong");
+		expect(["something"]).not.toContain("wrong");
+
+		// expect(["something"]).not.toContain("wrong", "should not contain 'wrong'");
+		expect(["something"]).not.toContain("wrong", "should not contain 'wrong'");
+
 		// expect($$('.a').count()).toBe(0);
 		expect($$('.a').count()).toBe(0);
 
+		const zero = 0;
+		// expect($$('.a').count()).toBe(0, "should have " + zero + " .a element");
+		expect($$('.a').count()).toBe(0, "should have " + zero + " .a element");
 	});
 
 	it('should add await when required', async () => {


### PR DESCRIPTION
It supports calls to `withContext` or the `expectationFailOutput` parameter.

Closes #7