### PR TITLE
Fix incorrectly added "await" when there is an assignment to a variable

### DIFF
--- a/scripts/protractor.ts
+++ b/scripts/protractor.ts
@@ -115,7 +115,7 @@ export function getTransformNode({stepStrategy}: {stepStrategy: 'test' | 'step'}
 			}
 		} else if (Node.isExpressionStatement(node)) {
 			const expression = node.getExpression();
-			if (promiseRegExp.test(expression.getType().getText())) {
+			if (!Node.isBinaryExpression(expression) && promiseRegExp.test(expression.getType().getText())) {
 				queueTransform(function() {
 					expression.replaceWithText(`await ${expression.getText()}`);
 				}, expression);

--- a/tests/playwright/src/callExpression.spec.ts
+++ b/tests/playwright/src/callExpression.spec.ts
@@ -92,6 +92,21 @@ test.describe('callExpression conversion', () => {
 
 	});
 
+	test('should not add await when not required', async ({page}) => {
+        setPage(page);
+		let promise;
+
+		// promise = $('.a').click();
+		promise = page.locator('.a').click();
+
+		await promise;
+
+		// promise = $('.a').click();
+		promise = page.locator('.a').click();
+
+		await promise;
+	});
+
 });
 
 test.describe('xdescribe conversion', () => {

--- a/tests/protractor/src/callExpression.spec.ts
+++ b/tests/protractor/src/callExpression.spec.ts
@@ -86,6 +86,20 @@ describe('callExpression conversion', () => {
 
 	});
 
+	it('should not add await when not required', async () => {
+		let promise;
+
+		// promise = $('.a').click();
+		promise = $('.a').click();
+
+		await promise;
+
+		// promise = $('.a').click();
+		promise = $('.a').click();
+
+		await promise;
+	});
+
 });
 
 xdescribe('xdescribe conversion', () => {


### PR DESCRIPTION
The following line:
```ts
promise = $('.a').click();
```
was incorrectly transformed into:
```ts
await promise = page.locator('.a').click();
```
This PR makes sure `await` is no longer added in that case:
```ts
promise = page.locator('.a').click();
```